### PR TITLE
Fix ODR.

### DIFF
--- a/tests/misc/bitvector_test.cpp
+++ b/tests/misc/bitvector_test.cpp
@@ -453,10 +453,3 @@ TEST(BitVectorTest, conversions) {
             std::cout << testv[i] << '\n';
     }
 }
-
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
-}

--- a/tests/misc/lru_cache_test.cpp
+++ b/tests/misc/lru_cache_test.cpp
@@ -53,9 +53,3 @@ TEST(CacheTest1, mtKeepsAllValuesWithinCapacity) {
         EXPECT_EQ(i, *cache.get(i));
     }
 }
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    int ret = RUN_ALL_TESTS();
-    return ret;
-}


### PR DESCRIPTION
The ``gmock_main`` library used in the tests already define the ``main`` function.