### PR TITLE
Fix MSVC & GCC warnings

### DIFF
--- a/include/gtl/gtl_config.hpp
+++ b/include/gtl/gtl_config.hpp
@@ -396,6 +396,12 @@
     #define GTL_ATTRIBUTE_FUNC_ALIGN(bytes)
 #endif
 
+#if GTL_HAVE_ATTRIBUTE(no_unique_address) || GTL_HAVE_CPP_ATTRIBUTE(no_unique_address)
+    #define GTL_ATTRIBUTE_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+    #define GTL_ATTRIBUTE_NO_UNIQUE_ADDRESS
+#endif
+
 // ----------------------------------------------------------------------
 // Figure out SSE support
 // ----------------------------------------------------------------------

--- a/include/gtl/phmap.hpp
+++ b/include/gtl/phmap.hpp
@@ -3179,7 +3179,7 @@ protected:
         }
 
         EmbeddedSet set_;
-        [[no_unique_address]] aux_type aux_;
+        GTL_ATTRIBUTE_NO_UNIQUE_ADDRESS aux_type aux_;
     };
 
 private:

--- a/tests/btree/btree_test.cpp
+++ b/tests/btree/btree_test.cpp
@@ -593,8 +593,8 @@ namespace {
         // Make sure various methods can be invoked on a const container.
         const_b.verify();
         ASSERT_TRUE(!const_b.empty());
-        EXPECT_EQ(const_b.size(), 1);
-        EXPECT_GT(const_b.max_size(), 0);
+        EXPECT_EQ(const_b.size(), 1u);
+        EXPECT_GT(const_b.max_size(), 0u);
         EXPECT_TRUE(const_b.contains(key_of_value(value)));
         EXPECT_EQ(const_b.count(key_of_value(value)), 1);
     }
@@ -2304,15 +2304,15 @@ namespace {
 
             tracker.ResetCopiesMovesSwaps();
             set2 = std::move(set1);
-            EXPECT_GE(tracker.moves(), 100);
+            EXPECT_GE(tracker.moves(), 100u);
         }
     }
 
     TEST(Btree, EmptyTree) {
         gtl::btree_set<int> s;
         EXPECT_TRUE(s.empty());
-        EXPECT_EQ(s.size(), 0);
-        EXPECT_GT(s.max_size(), 0);
+        EXPECT_EQ(s.size(), 0u);
+        EXPECT_GT(s.max_size(), 0u);
     }
 
     bool IsEven(int k) { return k % 2 == 0; }

--- a/tests/misc/lru_cache_test.cpp
+++ b/tests/misc/lru_cache_test.cpp
@@ -34,7 +34,7 @@ TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
     }
 
     size_t size = cache.size();
-    EXPECT_EQ(TEST2_CACHE_CAPACITY, size);
+    EXPECT_EQ(static_cast<size_t>(TEST2_CACHE_CAPACITY), size);
 }
 
 TEST(CacheTest1, mtKeepsAllValuesWithinCapacity) {

--- a/tests/phmap/compressed_tuple_test.cpp
+++ b/tests/phmap/compressed_tuple_test.cpp
@@ -107,9 +107,9 @@ TEST(CompressedTupleTest, Nested) {
   // MSVC has a bug where many instances of the same base class are layed out in
   // the same address when using __declspec(empty_bases).
   // This will be fixed in a future version of MSVC.
-  int expected = 1;
+  size_t expected = 1;
 #else
-  int expected = 4;
+  size_t expected = 4;
 #endif
   EXPECT_EQ(expected, sizeof(y));
   EXPECT_EQ(expected, empties.size());

--- a/tests/phmap/container_memory_test.cpp
+++ b/tests/phmap/container_memory_test.cpp
@@ -32,7 +32,7 @@ using ::testing::Pair;
 TEST(Memory, AlignmentLargerThanBase) {
   std::allocator<int8_t> alloc;
   void* mem = Allocate<2>(&alloc, 3);
-  EXPECT_EQ(0, reinterpret_cast<uintptr_t>(mem) % 2);
+  EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(mem) % 2);
   memcpy(mem, "abc", 3);
   Deallocate<2>(&alloc, mem, 3);
 }
@@ -40,7 +40,7 @@ TEST(Memory, AlignmentLargerThanBase) {
 TEST(Memory, AlignmentSmallerThanBase) {
   std::allocator<int64_t> alloc;
   void* mem = Allocate<2>(&alloc, 3);
-  EXPECT_EQ(0, reinterpret_cast<uintptr_t>(mem) % 2);
+  EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(mem) % 2);
   memcpy(mem, "abc", 3);
   Deallocate<2>(&alloc, mem, 3);
 }
@@ -102,7 +102,7 @@ TEST(PairArgs, Piecewise) {
 }
 
 TEST(WithConstructed, Simple) {
-  EXPECT_EQ(1, WithConstructed<std::string_view>(
+  EXPECT_EQ(1u, WithConstructed<std::string_view>(
                    std::make_tuple(std::string("a")),
                    [](std::string_view str) { return str.size(); }));
 }

--- a/tests/phmap/hash_policy_testing_test.cpp
+++ b/tests/phmap/hash_policy_testing_test.cpp
@@ -23,20 +23,20 @@ namespace {
 
 TEST(_, Hash) {
   StatefulTestingHash h1;
-  EXPECT_EQ(1, h1.id());
+  EXPECT_EQ(1u, h1.id());
   StatefulTestingHash h2;
-  EXPECT_EQ(2, h2.id());
+  EXPECT_EQ(2u, h2.id());
   StatefulTestingHash h1c(h1);
-  EXPECT_EQ(1, h1c.id());
+  EXPECT_EQ(1u, h1c.id());
   StatefulTestingHash h2m(std::move(h2));
-  EXPECT_EQ(2, h2m.id());
-  EXPECT_EQ(0, h2.id());
+  EXPECT_EQ(2u, h2m.id());
+  EXPECT_EQ(0u, h2.id());
   StatefulTestingHash h3;
-  EXPECT_EQ(3, h3.id());
+  EXPECT_EQ(3u, h3.id());
   h3 = StatefulTestingHash();
-  EXPECT_EQ(4, h3.id());
+  EXPECT_EQ(4u, h3.id());
   h3 = std::move(h1);
-  EXPECT_EQ(1, h3.id());
+  EXPECT_EQ(1u, h3.id());
 }
 
 }  // namespace

--- a/tests/phmap/parallel_hash_set_test.cpp
+++ b/tests/phmap/parallel_hash_set_test.cpp
@@ -125,10 +125,10 @@ TEST(THIS_TEST_NAME, EmplaceSingle) {
     // emplace_single insert a value if not already present, else removes it
     for (int i=0; i<12; ++i)
         m.emplace_single(i, [i](const Set::constructor& ctor) { ctor(i); });
-    EXPECT_EQ(m.count(0), 1);
-    EXPECT_EQ(m.count(1), 0);
-    EXPECT_EQ(m.count(2), 1);
-    EXPECT_EQ(m.count(11), 0);
+    EXPECT_EQ(m.count(0), 1u);
+    EXPECT_EQ(m.count(1), 0u);
+    EXPECT_EQ(m.count(2), 1u);
+    EXPECT_EQ(m.count(11), 0u);
 }
 
 }  // namespace

--- a/tests/phmap/raw_hash_set_allocator_test.cpp
+++ b/tests/phmap/raw_hash_set_allocator_test.cpp
@@ -190,120 +190,120 @@ using PropagateOnAll =
 using NoPropagateOnCopy = PropagateTest<kPropagateOnMove | kPropagateOnSwap>;
 using NoPropagateOnMove = PropagateTest<kPropagateOnCopy | kPropagateOnSwap>;
 
-TEST_F(PropagateOnAll, Empty) { EXPECT_EQ(0, a1.num_allocs()); }
+TEST_F(PropagateOnAll, Empty) { EXPECT_EQ(0u, a1.num_allocs()); }
 
 TEST_F(PropagateOnAll, InsertAllocates) {
   auto it = t1.insert(0).first;
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, InsertDecomposes) {
   auto it = t1.insert(0).first;
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 
   EXPECT_FALSE(t1.insert(0).second);
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, RehashMoves) {
   auto it = t1.insert(0).first;
-  EXPECT_EQ(0, it->num_moves());
+  EXPECT_EQ(0u, it->num_moves());
   t1.rehash(2 * t1.capacity());
-  EXPECT_EQ(2, a1.num_allocs());
+  EXPECT_EQ(2u, a1.num_allocs());
   it = t1.find(0);
-  EXPECT_EQ(1, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, CopyConstructor) {
   auto it = t1.insert(0).first;
   Table u(t1);
-  EXPECT_EQ(2, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(1, it->num_copies());
+  EXPECT_EQ(2u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(1u, it->num_copies());
 }
 
 TEST_F(NoPropagateOnCopy, CopyConstructor) {
   auto it = t1.insert(0).first;
   Table u(t1);
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(1, u.get_allocator().num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(1, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(1u, u.get_allocator().num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(1u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, CopyConstructorWithSameAlloc) {
   auto it = t1.insert(0).first;
   Table u(t1, a1);
-  EXPECT_EQ(2, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(1, it->num_copies());
+  EXPECT_EQ(2u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(1u, it->num_copies());
 }
 
 TEST_F(NoPropagateOnCopy, CopyConstructorWithSameAlloc) {
   auto it = t1.insert(0).first;
   Table u(t1, a1);
-  EXPECT_EQ(2, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(1, it->num_copies());
+  EXPECT_EQ(2u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(1u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, CopyConstructorWithDifferentAlloc) {
   auto it = t1.insert(0).first;
   Table u(t1, a2);
   EXPECT_EQ(a2, u.get_allocator());
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(1, a2.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(1, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(1u, a2.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(1u, it->num_copies());
 }
 
 TEST_F(NoPropagateOnCopy, CopyConstructorWithDifferentAlloc) {
   auto it = t1.insert(0).first;
   Table u(t1, a2);
   EXPECT_EQ(a2, u.get_allocator());
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(1, a2.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(1, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(1u, a2.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(1u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, MoveConstructor) {
   auto it = t1.insert(0).first;
   Table u(std::move(t1));
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(NoPropagateOnMove, MoveConstructor) {
   auto it = t1.insert(0).first;
   Table u(std::move(t1));
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, MoveConstructorWithSameAlloc) {
   auto it = t1.insert(0).first;
   Table u(std::move(t1), a1);
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(NoPropagateOnMove, MoveConstructorWithSameAlloc) {
   auto it = t1.insert(0).first;
   Table u(std::move(t1), a1);
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, MoveConstructorWithDifferentAlloc) {
@@ -311,10 +311,10 @@ TEST_F(PropagateOnAll, MoveConstructorWithDifferentAlloc) {
   Table u(std::move(t1), a2);
   it = u.find(0);
   EXPECT_EQ(a2, u.get_allocator());
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(1, a2.num_allocs());
-  EXPECT_EQ(1, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(1u, a2.num_allocs());
+  EXPECT_EQ(1u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(NoPropagateOnMove, MoveConstructorWithDifferentAlloc) {
@@ -322,28 +322,28 @@ TEST_F(NoPropagateOnMove, MoveConstructorWithDifferentAlloc) {
   Table u(std::move(t1), a2);
   it = u.find(0);
   EXPECT_EQ(a2, u.get_allocator());
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(1, a2.num_allocs());
-  EXPECT_EQ(1, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(1u, a2.num_allocs());
+  EXPECT_EQ(1u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, CopyAssignmentWithSameAlloc) {
   auto it = t1.insert(0).first;
   Table u(0, a1);
   u = t1;
-  EXPECT_EQ(2, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(1, it->num_copies());
+  EXPECT_EQ(2u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(1u, it->num_copies());
 }
 
 TEST_F(NoPropagateOnCopy, CopyAssignmentWithSameAlloc) {
   auto it = t1.insert(0).first;
   Table u(0, a1);
   u = t1;
-  EXPECT_EQ(2, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(1, it->num_copies());
+  EXPECT_EQ(2u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(1u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, CopyAssignmentWithDifferentAlloc) {
@@ -351,10 +351,10 @@ TEST_F(PropagateOnAll, CopyAssignmentWithDifferentAlloc) {
   Table u(0, a2);
   u = t1;
   EXPECT_EQ(a1, u.get_allocator());
-  EXPECT_EQ(2, a1.num_allocs());
-  EXPECT_EQ(0, a2.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(1, it->num_copies());
+  EXPECT_EQ(2u, a1.num_allocs());
+  EXPECT_EQ(0u, a2.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(1u, it->num_copies());
 }
 
 TEST_F(NoPropagateOnCopy, CopyAssignmentWithDifferentAlloc) {
@@ -362,10 +362,10 @@ TEST_F(NoPropagateOnCopy, CopyAssignmentWithDifferentAlloc) {
   Table u(0, a2);
   u = t1;
   EXPECT_EQ(a2, u.get_allocator());
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(1, a2.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(1, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(1u, a2.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(1u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, MoveAssignmentWithSameAlloc) {
@@ -373,9 +373,9 @@ TEST_F(PropagateOnAll, MoveAssignmentWithSameAlloc) {
   Table u(0, a1);
   u = std::move(t1);
   EXPECT_EQ(a1, u.get_allocator());
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(NoPropagateOnMove, MoveAssignmentWithSameAlloc) {
@@ -383,9 +383,9 @@ TEST_F(NoPropagateOnMove, MoveAssignmentWithSameAlloc) {
   Table u(0, a1);
   u = std::move(t1);
   EXPECT_EQ(a1, u.get_allocator());
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, MoveAssignmentWithDifferentAlloc) {
@@ -393,10 +393,10 @@ TEST_F(PropagateOnAll, MoveAssignmentWithDifferentAlloc) {
   Table u(0, a2);
   u = std::move(t1);
   EXPECT_EQ(a1, u.get_allocator());
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, a2.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, a2.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(NoPropagateOnMove, MoveAssignmentWithDifferentAlloc) {
@@ -405,10 +405,10 @@ TEST_F(NoPropagateOnMove, MoveAssignmentWithDifferentAlloc) {
   u = std::move(t1);
   it = u.find(0);
   EXPECT_EQ(a2, u.get_allocator());
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(1, a2.num_allocs());
-  EXPECT_EQ(1, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(1u, a2.num_allocs());
+  EXPECT_EQ(1u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 TEST_F(PropagateOnAll, Swap) {
@@ -417,10 +417,10 @@ TEST_F(PropagateOnAll, Swap) {
   u.swap(t1);
   EXPECT_EQ(a1, u.get_allocator());
   EXPECT_EQ(a2, t1.get_allocator());
-  EXPECT_EQ(1, a1.num_allocs());
-  EXPECT_EQ(0, a2.num_allocs());
-  EXPECT_EQ(0, it->num_moves());
-  EXPECT_EQ(0, it->num_copies());
+  EXPECT_EQ(1u, a1.num_allocs());
+  EXPECT_EQ(0u, a2.num_allocs());
+  EXPECT_EQ(0u, it->num_moves());
+  EXPECT_EQ(0u, it->num_copies());
 }
 
 }  // namespace

--- a/tests/phmap/raw_hash_set_test.cpp
+++ b/tests/phmap/raw_hash_set_test.cpp
@@ -60,16 +60,16 @@ using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 
 TEST(Util, NormalizeCapacity) {
-  EXPECT_EQ(1, NormalizeCapacity(0));
-  EXPECT_EQ(1, NormalizeCapacity(1));
-  EXPECT_EQ(3, NormalizeCapacity(2));
-  EXPECT_EQ(3, NormalizeCapacity(3));
-  EXPECT_EQ(7, NormalizeCapacity(4));
-  EXPECT_EQ(7, NormalizeCapacity(7));
-  EXPECT_EQ(15, NormalizeCapacity(8));
-  EXPECT_EQ(15, NormalizeCapacity(15));
-  EXPECT_EQ(15 * 2 + 1, NormalizeCapacity(15 + 1));
-  EXPECT_EQ(15 * 2 + 1, NormalizeCapacity(15 + 2));
+  EXPECT_EQ(1u, NormalizeCapacity(0));
+  EXPECT_EQ(1u, NormalizeCapacity(1));
+  EXPECT_EQ(3u, NormalizeCapacity(2));
+  EXPECT_EQ(3u, NormalizeCapacity(3));
+  EXPECT_EQ(7u, NormalizeCapacity(4));
+  EXPECT_EQ(7u, NormalizeCapacity(7));
+  EXPECT_EQ(15u, NormalizeCapacity(8));
+  EXPECT_EQ(15u, NormalizeCapacity(15));
+  EXPECT_EQ(15u * 2 + 1, NormalizeCapacity(15 + 1));
+  EXPECT_EQ(15u * 2 + 1, NormalizeCapacity(15 + 2));
 }
 
 TEST(Util, GrowthAndCapacity) {
@@ -418,7 +418,7 @@ TEST(Table, EmptyFunctorOptimization) {
 
 TEST(Table, Empty) {
   IntTable t;
-  EXPECT_EQ(0, t.size());
+  EXPECT_EQ(0u, t.size());
   EXPECT_TRUE(t.empty());
 }
 
@@ -481,7 +481,7 @@ TEST(Table, Insert1) {
   auto res = t.emplace(0);
   EXPECT_TRUE(res.second);
   EXPECT_THAT(*res.first, 0);
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   EXPECT_THAT(*t.find(0), 0);
 }
 
@@ -491,12 +491,12 @@ TEST(Table, Insert2) {
   auto res = t.emplace(0);
   EXPECT_TRUE(res.second);
   EXPECT_THAT(*res.first, 0);
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   EXPECT_TRUE(t.find(1) == t.end());
   res = t.emplace(1);
   EXPECT_TRUE(res.second);
   EXPECT_THAT(*res.first, 1);
-  EXPECT_EQ(2, t.size());
+  EXPECT_EQ(2u, t.size());
   EXPECT_THAT(*t.find(0), 0);
   EXPECT_THAT(*t.find(1), 1);
 }
@@ -507,13 +507,13 @@ TEST(Table, InsertCollision) {
   auto res = t.emplace(1);
   EXPECT_TRUE(res.second);
   EXPECT_THAT(*res.first, 1);
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
 
   EXPECT_TRUE(t.find(2) == t.end());
   res = t.emplace(2);
   EXPECT_THAT(*res.first, 2);
   EXPECT_TRUE(res.second);
-  EXPECT_EQ(2, t.size());
+  EXPECT_EQ(2u, t.size());
 
   EXPECT_THAT(*t.find(1), 1);
   EXPECT_THAT(*t.find(2), 2);
@@ -536,7 +536,7 @@ TEST(Table, InsertCollisionAndFindAfterDelete) {
   // Remove elements one by one and check
   // that we still can find all other elements.
   for (size_t i = 0; i < kNumInserts; ++i) {
-    EXPECT_EQ(1, t.erase(i)) << i;
+    EXPECT_EQ(1u, t.erase(i)) << i;
     for (size_t j = i + 1; j < kNumInserts; ++j) {
       EXPECT_THAT(*t.find(j), j);
       auto res = t.emplace(j);
@@ -579,7 +579,7 @@ TEST(Table, Contains1) {
   EXPECT_TRUE(t.contains(0));
   EXPECT_FALSE(t.contains(1));
 
-  EXPECT_EQ(1, t.erase(0));
+  EXPECT_EQ(1u, t.erase(0));
   EXPECT_FALSE(t.contains(0));
 }
 
@@ -799,7 +799,7 @@ TEST(Table, InsertEraseStressTest) {
   }
   const size_t kNumIterations = 1000000;
   for (; i < kNumIterations; ++i) {
-    ASSERT_EQ(1, t.erase(keys.front()));
+    ASSERT_EQ(1u, t.erase(keys.front()));
     keys.pop_front();
     t.emplace(i);
     keys.push_back(i);
@@ -865,9 +865,9 @@ TEST(Table, Erase) {
   EXPECT_TRUE(t.find(0) == t.end());
   auto res = t.emplace(0);
   EXPECT_TRUE(res.second);
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   t.erase(res.first);
-  EXPECT_EQ(0, t.size());
+  EXPECT_EQ(0u, t.size());
   EXPECT_TRUE(t.find(0) == t.end());
 }
 
@@ -877,7 +877,7 @@ TEST(Table, EraseMaintainsValidIterator) {
   for (int i = 0; i < kNumElements; i ++) {
     EXPECT_TRUE(t.emplace(i).second);
   }
-  EXPECT_EQ(t.size(), kNumElements);
+  EXPECT_EQ(t.size(), static_cast<size_t>(kNumElements));
 
    int num_erase_calls = 0;
   auto it = t.begin();
@@ -1262,28 +1262,28 @@ TEST(Table, EraseCollision) {
   EXPECT_THAT(*t.find(1), 1);
   EXPECT_THAT(*t.find(2), 2);
   EXPECT_THAT(*t.find(3), 3);
-  EXPECT_EQ(3, t.size());
+  EXPECT_EQ(3u, t.size());
 
   // 1 DELETED 3
   t.erase(t.find(2));
   EXPECT_THAT(*t.find(1), 1);
   EXPECT_TRUE(t.find(2) == t.end());
   EXPECT_THAT(*t.find(3), 3);
-  EXPECT_EQ(2, t.size());
+  EXPECT_EQ(2u, t.size());
 
   // DELETED DELETED 3
   t.erase(t.find(1));
   EXPECT_TRUE(t.find(1) == t.end());
   EXPECT_TRUE(t.find(2) == t.end());
   EXPECT_THAT(*t.find(3), 3);
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
 
   // DELETED DELETED DELETED
   t.erase(t.find(3));
   EXPECT_TRUE(t.find(1) == t.end());
   EXPECT_TRUE(t.find(2) == t.end());
   EXPECT_TRUE(t.find(3) == t.end());
-  EXPECT_EQ(0, t.size());
+  EXPECT_EQ(0u, t.size());
 }
 
 TEST(Table, EraseInsertProbing) {
@@ -1304,7 +1304,7 @@ TEST(Table, EraseInsertProbing) {
   t.emplace(11);
   t.emplace(12);
 
-  EXPECT_EQ(5, t.size());
+  EXPECT_EQ(5u, t.size());
   EXPECT_THAT(t, UnorderedElementsAre(1, 10, 3, 11, 12));
 }
 
@@ -1315,9 +1315,9 @@ TEST(Table, Clear) {
   EXPECT_TRUE(t.find(0) == t.end());
   auto res = t.emplace(0);
   EXPECT_TRUE(res.second);
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   t.clear();
-  EXPECT_EQ(0, t.size());
+  EXPECT_EQ(0u, t.size());
   EXPECT_TRUE(t.find(0) == t.end());
 }
 
@@ -1326,11 +1326,11 @@ TEST(Table, Swap) {
   EXPECT_TRUE(t.find(0) == t.end());
   auto res = t.emplace(0);
   EXPECT_TRUE(res.second);
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   IntTable u;
   t.swap(u);
-  EXPECT_EQ(0, t.size());
-  EXPECT_EQ(1, u.size());
+  EXPECT_EQ(0u, t.size());
+  EXPECT_EQ(1u, u.size());
   EXPECT_TRUE(t.find(0) == t.end());
   EXPECT_THAT(*u.find(0), 0);
 }
@@ -1340,9 +1340,9 @@ TEST(Table, Rehash) {
   EXPECT_TRUE(t.find(0) == t.end());
   t.emplace(0);
   t.emplace(1);
-  EXPECT_EQ(2, t.size());
+  EXPECT_EQ(2u, t.size());
   t.rehash(128);
-  EXPECT_EQ(2, t.size());
+  EXPECT_EQ(2u, t.size());
   EXPECT_THAT(*t.find(0), 0);
   EXPECT_THAT(*t.find(1), 1);
 }
@@ -1359,16 +1359,16 @@ TEST(Table, RehashDoesNotRehashWhenNotNecessary) {
 TEST(Table, RehashZeroDoesNotAllocateOnEmptyTable) {
   IntTable t;
   t.rehash(0);
-  EXPECT_EQ(0, t.bucket_count());
+  EXPECT_EQ(0u, t.bucket_count());
 }
 
 TEST(Table, RehashZeroDeallocatesEmptyTable) {
   IntTable t;
   t.emplace(0);
   t.clear();
-  EXPECT_NE(0, t.bucket_count());
+  EXPECT_NE(0u, t.bucket_count());
   t.rehash(0);
-  EXPECT_EQ(0, t.bucket_count());
+  EXPECT_EQ(0u, t.bucket_count());
 }
 
 TEST(Table, RehashZeroForcesRehash) {
@@ -1391,20 +1391,20 @@ TEST(Table, ConstructFromInitList) {
 TEST(Table, CopyConstruct) {
   IntTable t;
   t.emplace(0);
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   {
     IntTable u(t);
-    EXPECT_EQ(1, u.size());
+    EXPECT_EQ(1u, u.size());
     EXPECT_THAT(*u.find(0), 0);
   }
   {
     IntTable u{t};
-    EXPECT_EQ(1, u.size());
+    EXPECT_EQ(1u, u.size());
     EXPECT_THAT(*u.find(0), 0);
   }
   {
     IntTable u = t;
-    EXPECT_EQ(1, u.size());
+    EXPECT_EQ(1u, u.size());
     EXPECT_THAT(*u.find(0), 0);
   }
 }
@@ -1412,9 +1412,9 @@ TEST(Table, CopyConstruct) {
 TEST(Table, CopyConstructWithAlloc) {
   StringTable t;
   t.emplace("a", "b");
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   StringTable u(t, Alloc<std::pair<std::string, std::string>>());
-  EXPECT_EQ(1, u.size());
+  EXPECT_EQ(1u, u.size());
   EXPECT_THAT(*u.find("a"), Pair("a", "b"));
 }
 
@@ -1426,35 +1426,35 @@ struct ExplicitAllocIntTable
 
 TEST(Table, AllocWithExplicitCtor) {
   ExplicitAllocIntTable t;
-  EXPECT_EQ(0, t.size());
+  EXPECT_EQ(0u, t.size());
 }
 
 TEST(Table, MoveConstruct) {
   {
     StringTable t;
     t.emplace("a", "b");
-    EXPECT_EQ(1, t.size());
+    EXPECT_EQ(1u, t.size());
 
     StringTable u(std::move(t));
-    EXPECT_EQ(1, u.size());
+    EXPECT_EQ(1u, u.size());
     EXPECT_THAT(*u.find("a"), Pair("a", "b"));
   }
   {
     StringTable t;
     t.emplace("a", "b");
-    EXPECT_EQ(1, t.size());
+    EXPECT_EQ(1u, t.size());
 
     StringTable u{std::move(t)};
-    EXPECT_EQ(1, u.size());
+    EXPECT_EQ(1u, u.size());
     EXPECT_THAT(*u.find("a"), Pair("a", "b"));
   }
   {
     StringTable t;
     t.emplace("a", "b");
-    EXPECT_EQ(1, t.size());
+    EXPECT_EQ(1u, t.size());
 
     StringTable u = std::move(t);
-    EXPECT_EQ(1, u.size());
+    EXPECT_EQ(1u, u.size());
     EXPECT_THAT(*u.find("a"), Pair("a", "b"));
   }
 }
@@ -1462,38 +1462,38 @@ TEST(Table, MoveConstruct) {
 TEST(Table, MoveConstructWithAlloc) {
   StringTable t;
   t.emplace("a", "b");
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   StringTable u(std::move(t), Alloc<std::pair<std::string, std::string>>());
-  EXPECT_EQ(1, u.size());
+  EXPECT_EQ(1u, u.size());
   EXPECT_THAT(*u.find("a"), Pair("a", "b"));
 }
 
 TEST(Table, CopyAssign) {
   StringTable t;
   t.emplace("a", "b");
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   StringTable u;
   u = t;
-  EXPECT_EQ(1, u.size());
+  EXPECT_EQ(1u, u.size());
   EXPECT_THAT(*u.find("a"), Pair("a", "b"));
 }
 
 TEST(Table, CopySelfAssign) {
   StringTable t;
   t.emplace("a", "b");
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   t = *&t;
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   EXPECT_THAT(*t.find("a"), Pair("a", "b"));
 }
 
 TEST(Table, MoveAssign) {
   StringTable t;
   t.emplace("a", "b");
-  EXPECT_EQ(1, t.size());
+  EXPECT_EQ(1u, t.size());
   StringTable u;
   u = std::move(t);
-  EXPECT_EQ(1, u.size());
+  EXPECT_EQ(1u, u.size());
   EXPECT_THAT(*u.find("a"), Pair("a", "b"));
 }
 
@@ -1545,7 +1545,7 @@ TEST(Table, FindFullDeletedRegression) {
     t.emplace(i);
     t.erase(t.find(i));
   }
-  EXPECT_EQ(0, t.size());
+  EXPECT_EQ(0u, t.size());
 }
 
 TEST(Table, ReplacingDeletedSlotDoesNotRehash) {
@@ -1876,7 +1876,7 @@ TEST(Sanitizer, PoisoningUnused) {
   int64_t& v1 = *t.insert(0).first;
 
   // Make sure there is something to test.
-  ASSERT_GT(t.capacity(), 1);
+  ASSERT_GT(t.capacity(), 1u);
 
   int64_t* slots = RawHashSetTestOnlyAccess::GetSlots(t);
   for (size_t i = 0; i < t.capacity(); ++i) {

--- a/tests/phmap/unordered_set_constructor_test.hpp
+++ b/tests/phmap/unordered_set_constructor_test.hpp
@@ -42,7 +42,7 @@ TYPED_TEST_P(ConstructorTest, BucketCount) {
   TypeParam m(123);
   EXPECT_TRUE(m.empty());
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAre());
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 TYPED_TEST_P(ConstructorTest, BucketCountHash) {
@@ -52,7 +52,7 @@ TYPED_TEST_P(ConstructorTest, BucketCountHash) {
   EXPECT_EQ(m.hash_function(), hasher);
   EXPECT_TRUE(m.empty());
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAre());
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 TYPED_TEST_P(ConstructorTest, BucketCountHashEqual) {
@@ -65,7 +65,7 @@ TYPED_TEST_P(ConstructorTest, BucketCountHashEqual) {
   EXPECT_EQ(m.key_eq(), equal);
   EXPECT_TRUE(m.empty());
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAre());
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 TYPED_TEST_P(ConstructorTest, BucketCountHashEqualAlloc) {
@@ -81,7 +81,7 @@ TYPED_TEST_P(ConstructorTest, BucketCountHashEqualAlloc) {
   EXPECT_EQ(m.get_allocator(), alloc);
   EXPECT_TRUE(m.empty());
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAre());
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 
   const auto& cm = m;
   EXPECT_EQ(cm.hash_function(), hasher);
@@ -89,7 +89,7 @@ TYPED_TEST_P(ConstructorTest, BucketCountHashEqualAlloc) {
   EXPECT_EQ(cm.get_allocator(), alloc);
   EXPECT_TRUE(cm.empty());
   EXPECT_THAT(keys(cm), ::testing::UnorderedElementsAre());
-  EXPECT_GE(cm.bucket_count(), 123);
+  EXPECT_GE(cm.bucket_count(), 123u);
 }
 
 template <typename T>
@@ -120,7 +120,7 @@ void BucketCountAllocTest(std::true_type) {
   EXPECT_EQ(m.get_allocator(), alloc);
   EXPECT_TRUE(m.empty());
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAre());
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 TYPED_TEST_P(ConstructorTest, BucketCountAlloc) {
@@ -141,7 +141,7 @@ void BucketCountHashAllocTest(std::true_type) {
   EXPECT_EQ(m.get_allocator(), alloc);
   EXPECT_TRUE(m.empty());
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAre());
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 TYPED_TEST_P(ConstructorTest, BucketCountHashAlloc) {
@@ -192,7 +192,7 @@ TYPED_TEST_P(ConstructorTest, InputIteratorBucketHashEqualAlloc) {
   EXPECT_EQ(m.key_eq(), equal);
   EXPECT_EQ(m.get_allocator(), alloc);
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAreArray(values));
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 template <typename TypeParam>
@@ -209,7 +209,7 @@ void InputIteratorBucketAllocTest(std::true_type) {
   TypeParam m(values.begin(), values.end(), 123, alloc);
   EXPECT_EQ(m.get_allocator(), alloc);
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAreArray(values));
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 TYPED_TEST_P(ConstructorTest, InputIteratorBucketAlloc) {
@@ -233,7 +233,7 @@ void InputIteratorBucketHashAllocTest(std::true_type) {
   EXPECT_EQ(m.hash_function(), hasher);
   EXPECT_EQ(m.get_allocator(), alloc);
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAreArray(values));
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 TYPED_TEST_P(ConstructorTest, InputIteratorBucketHashAlloc) {
@@ -346,7 +346,7 @@ TYPED_TEST_P(ConstructorTest, InitializerListBucketHashEqualAlloc) {
   EXPECT_EQ(m.key_eq(), equal);
   EXPECT_EQ(m.get_allocator(), alloc);
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAreArray(values));
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 template <typename TypeParam>
@@ -362,7 +362,7 @@ void InitializerListBucketAllocTest(std::true_type) {
   TypeParam m(values, 123, alloc);
   EXPECT_EQ(m.get_allocator(), alloc);
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAreArray(values));
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 TYPED_TEST_P(ConstructorTest, InitializerListBucketAlloc) {
@@ -385,7 +385,7 @@ void InitializerListBucketHashAllocTest(std::true_type) {
   EXPECT_EQ(m.hash_function(), hasher);
   EXPECT_EQ(m.get_allocator(), alloc);
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAreArray(values));
-  EXPECT_GE(m.bucket_count(), 123);
+  EXPECT_GE(m.bucket_count(), 123u);
 }
 
 TYPED_TEST_P(ConstructorTest, InitializerListBucketHashAlloc) {

--- a/tests/phmap/unordered_set_lookup_test.hpp
+++ b/tests/phmap/unordered_set_lookup_test.hpp
@@ -35,10 +35,10 @@ TYPED_TEST_P(LookupTest, Count) {
                   hash_internal::Generator<T>());
   TypeParam m;
   for (const auto& v : values)
-    EXPECT_EQ(0, m.count(v)) << ::testing::PrintToString(v);
+    EXPECT_EQ(0u, m.count(v)) << ::testing::PrintToString(v);
   m.insert(values.begin(), values.end());
   for (const auto& v : values)
-    EXPECT_EQ(1, m.count(v)) << ::testing::PrintToString(v);
+    EXPECT_EQ(1u, m.count(v)) << ::testing::PrintToString(v);
 }
 
 TYPED_TEST_P(LookupTest, Find) {

--- a/tests/phmap/unordered_set_members_test.hpp
+++ b/tests/phmap/unordered_set_members_test.hpp
@@ -64,7 +64,7 @@ TYPED_TEST_P(MembersTest, Typedefs) {
 }
 
 TYPED_TEST_P(MembersTest, SimpleFunctions) {
-  EXPECT_GT(TypeParam().max_size(), 0);
+  EXPECT_GT(TypeParam().max_size(), 0u);
 }
 
 TYPED_TEST_P(MembersTest, BeginEnd) {

--- a/tests/phmap/unordered_set_modifiers_test.hpp
+++ b/tests/phmap/unordered_set_modifiers_test.hpp
@@ -154,7 +154,7 @@ TYPED_TEST_P(ModifiersTest, EraseKey) {
                   hash_internal::Generator<T>());
   TypeParam m(values.begin(), values.end());
   ASSERT_THAT(keys(m), ::testing::UnorderedElementsAreArray(values));
-  EXPECT_EQ(1, m.erase(values[0]));
+  EXPECT_EQ(1u, m.erase(values[0]));
   EXPECT_EQ(0, std::count(m.begin(), m.end(), values[0]));
   EXPECT_THAT(keys(m), ::testing::UnorderedElementsAreArray(values.begin() + 1,
                                                             values.end()));


### PR DESCRIPTION
**Fix bogous MSVC Win32 signed/unsigned mismatch warnings in tests**

Before:
```
    21 Warning(s)
    0 Error(s)
```

After:
```
    0 Warning(s)
    0 Error(s)
```


**Fix GCC-8 warning: ‘no_unique_address’ attribute directive ignored**

GCC-8 does not support 'no_unique_address' attribute.
