### PR TITLE
Fixed Visual Studio compiler warning

### DIFF
--- a/include/gtl/vector.hpp
+++ b/include/gtl/vector.hpp
@@ -1311,12 +1311,12 @@ private: // we have the private section first because it defines some macros
             impl_.e_ += n;
         } else {
             if constexpr (std::is_trivially_copyable_v<T> && usingStdAllocator) {
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wnonnull" // disable erroneous warning
 #endif
                 std::memmove((void*)(position + n), (void*)position, tail * sizeof(T));
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
     #pragma GCC diagnostic pop
 #endif
                 impl_.e_ += n;

--- a/include/gtl/vector.hpp
+++ b/include/gtl/vector.hpp
@@ -1311,10 +1311,14 @@ private: // we have the private section first because it defines some macros
             impl_.e_ += n;
         } else {
             if constexpr (std::is_trivially_copyable_v<T> && usingStdAllocator) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnonnull" // disable erroneous warning
+#if defined(__GNUC__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wnonnull" // disable erroneous warning
+#endif
                 std::memmove((void*)(position + n), (void*)position, tail * sizeof(T));
-#pragma GCC diagnostic pop
+#if defined(__GNUC__)
+    #pragma GCC diagnostic pop
+#endif
                 impl_.e_ += n;
             } else {
                 D_uninitialized_move_a(impl_.e_, impl_.e_ - n, impl_.e_);


### PR DESCRIPTION
"#pragma GCC" causes warning 4068 "Unknown pragma" when compiling with Visual Studio 2022. Maybe the condition should be
    #if defined(__GNUC__) || defined(__clang__)
instead. Both are used in the other files.