### PR TITLE
README: Tagged CMake section and fixed indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ FetchContent_Declare(
     GIT_TAG        v1.2.0 # adjust tag/branch/commit as needed
 )
 FetchContent_MakeAvailable(gtl)
+
 ...
 target_link_libraries (my_target PRIVATE gtl)
 ```

--- a/README.md
+++ b/README.md
@@ -33,17 +33,16 @@ Copy the gtl directory to your project. Update your include path. That's all.
 
 If you are using cmake, you can use FetchContent to integrate gtl to your project, for example:
 
-```
-    include(FetchContent)
-    FetchContent_Declare(
-        gtl
-        GIT_REPOSITORY https://github.com/greg7mdp/gtl.git
-        GIT_TAG        v1.2.0 # adjust tag/branch/commit as needed
-    )
-    FetchContent_MakeAvailable(gtl)
-
-    ...
-    target_link_libraries (my_target PRIVATE gtl)
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+    gtl
+    GIT_REPOSITORY https://github.com/greg7mdp/gtl.git
+    GIT_TAG        v1.2.0 # adjust tag/branch/commit as needed
+)
+FetchContent_MakeAvailable(gtl)
+...
+target_link_libraries (my_target PRIVATE gtl)
 ```
 
 #### Using a package manager


### PR DESCRIPTION
CMake snippets can be tagged with the `cmake` keyword in markdown to give it automatic colors. Also moved the indent a little.