### PR TITLE
Fix CMake export failure when gtl is fetched via FetchContent and linked as PUBLIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,6 @@ include(helpers)
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-target_sources(${PROJECT_NAME} INTERFACE ${GTL_HEADERS})
-
 target_include_directories(
      ${PROJECT_NAME} INTERFACE
      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
@@ -94,7 +92,12 @@ if(GTL_INSTALL)
     install(TARGETS ${PROJECT_NAME}
             EXPORT ${PROJECT_NAME}-targets)
 
-    export(EXPORT ${PROJECT_NAME}-targets
+    install(EXPORT ${PROJECT_NAME}-targets
+            NAMESPACE ${namespace}
+            DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME})
+
+    export(TARGETS ${PROJECT_NAME}
+           NAMESPACE ${namespace}
            FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
 endif()
 


### PR DESCRIPTION
## Summary
If use gtl from CMake `FetchContent` and link it as `PUBLIC`, there will be error:
```
CMake Error in CMakeLists.txt:
   install(EXPORT "RepoduceTargets" ...) includes target "Repoduce" which
   requires target "gtl" that is not in any export set.
```
This prevents gtl from being used in public interface of a library. This PR fixes the issue without breaking existing behavior.

The CMake export follows the style used in [Microsoft GSL](https://github.com/microsoft/GSL).

## Minimum reproduce example
```cmake
cmake_minimum_required(VERSION 3.20)
project(Repoduce LANGUAGES CXX)

include(FetchContent)

FetchContent_Declare(
  gtl
  GIT_REPOSITORY https://github.com/greg7mdp/gtl.git
  GIT_TAG v1.2.0
)
FetchContent_MakeAvailable(gtl)

# Create a library target
file(WRITE "${CMAKE_BINARY_DIR}/repoduce_dummy.cpp" "int repoduce_dummy() { return 0; }\n")
add_library(Repoduce STATIC "${CMAKE_BINARY_DIR}/repoduce_dummy.cpp")

target_link_libraries(Repoduce PUBLIC gtl)

include(GNUInstallDirs)

install(TARGETS Repoduce EXPORT RepoduceTargets)
install(EXPORT RepoduceTargets
  FILE RepoduceTargets.cmake
  NAMESPACE Repoduce::
  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Repoduce"
)
```
This CMakeLists.txt will produce the error.