### PR TITLE
Fix some warnings

### DIFF
--- a/include/gtl/phmap.hpp
+++ b/include/gtl/phmap.hpp
@@ -4326,7 +4326,7 @@ private:
     struct HashElement {
         template<class K, class... Args>
         size_t operator()(const K& key, Args&&...) const {
-#if GTL_DISABLE_MIX
+#ifdef GTL_DISABLE_MIX
             return h(key);
 #else
             return phmap_mix<sizeof(size_t)>()(h(key));

--- a/include/gtl/phmap.hpp
+++ b/include/gtl/phmap.hpp
@@ -2533,7 +2533,7 @@ private:
     struct HashElement {
         template<class K, class... Args>
         size_t operator()(const K& key, Args&&...) const {
-#if GTL_DISABLE_MIX
+#ifdef GTL_DISABLE_MIX
             return h(key);
 #else
             return phmap_mix<sizeof(size_t)>()(static_cast<size_t>(h(key)));

--- a/include/gtl/vector.hpp
+++ b/include/gtl/vector.hpp
@@ -777,7 +777,7 @@ public:
                 // can't use other's different allocator to clean up self
                 impl_.reset();
             }
-            (Allocator&)impl_ = (Allocator&)other.impl_;
+            static_cast<Allocator&>(impl_) = static_cast<const Allocator&>(other.impl_);
         }
 
         assign(other.begin(), other.end());


### PR DESCRIPTION
## Summary
This PR addresses two compiler warnings.

1. `-Wundef` from undefined macro `GTL_DISABLE_MIX`. It seems not defined anywhere inside the repo, including CMake, so it is either (a) defined by user, or (b) redundant. I assumed (a) here.
2. `-Wcast-qual` in expression `(Allocator&)impl_ = (Allocator&)other.impl_`. Since `other` is const, then `other.impl_` should also be const. Former code casts away constness.